### PR TITLE
Allowed rerendering of shipments table upon delete

### DIFF
--- a/src/components/shipment/Shipment.js
+++ b/src/components/shipment/Shipment.js
@@ -163,73 +163,150 @@
 
 // export default withStyles(styles)(Shipment);
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
-import Icon from '@material-ui/core/Icon';
-import classNames from 'classnames';
-import Checkbox from '@material-ui/core/Checkbox';
-import ViewShipmentModal from '../modals/ViewShipmentModal';
-import moment from "moment"
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Icon from "@material-ui/core/Icon";
+import classNames from "classnames";
+import Checkbox from "@material-ui/core/Checkbox";
+import ViewShipmentModal from "../modals/ViewShipmentModal";
+import moment from "moment";
+
+function Shipment(props) {
+  const { classes } = props;
+  // const handleFilter = () => {
+  // 	if(props.shipment && props.shipment.track === 1) {
+
+  // 	}
+  // }
+  return (
+    <TableRow hover role="checkbox" tabIndex={-1}>
+        <TableCell padding="checkbox">
+          <Checkbox
+            checked={props.isSelected}
+            onClick={event => props.handleClick(event, props.shipment.uuid)}
+          />
+        </TableCell>
+        <TableCell align="right">
+          {moment(props.shipment.lastUpdated).format("L h:mm a")}
+        </TableCell>
+        {props.shipment.status ? (
+          <TableCell align="center">
+            {props.shipment.status}
+          </TableCell>
+        ) : (
+          <TableCell align="right">
+            <button>Add Tracking Number</button>
+          </TableCell>
+        )}
+        <TableCell align="right">{props.shipment.totalWeight}</TableCell>
+        <TableCell align="right">{props.shipment.dimensions}</TableCell>
+        <TableCell align="right">
+          {props.shipment.productNames.join(", ")}
+        </TableCell>
+    </TableRow>
+  );
+}
+
+Shipment.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(Shipment);
+
+const parsedStatus = n => {
+  if (n.status === 0) {
+    return "Unknown";
+  }
+  if (n.status === 1) {
+    return "Shipping";
+  }
+  if (n.status === 2) {
+    return "En-Route";
+  }
+  if (n.status === 3) {
+    return "Out-For-Delivery";
+  }
+  if (n.status === 4) {
+    return "Delivered";
+  }
+  if (n.status === 5) {
+    return "Delayed";
+  }
+};
+
+const statusStyling = n => {
+  if (n.status === 0) {
+    return {
+      backgroundColor: "#ffa9a8",
+      borderRadius: "25px",
+      paddingRight: "5px"
+    };
+  }
+  if (n.status === 1) {
+    return {
+      backgroundColor: "#ffc642",
+      borderRadius: "25px",
+      paddingRight: "5px"
+    };
+  }
+  if (n.status === 2) {
+    return {
+      backgroundColor: "#ffc642",
+      borderRadius: "25px",
+      paddingRight: "5px"
+    };
+  }
+  if (n.status === 3) {
+    return {
+      backgroundColor: "#ffc642",
+      borderRadius: "25px",
+      paddingRight: "5px"
+    };
+  }
+  if (n.status === 4) {
+    return {
+      backgroundColor: "#a7c2a6",
+      borderRadius: "25px",
+      paddingRight: "5px"
+    };
+  }
+  if (n.status === 5) {
+    return {
+      backgroundColor: "#ffa9a8",
+      borderRadius: "25px",
+      paddingRight: "5px"
+    };
+  }
+};
 
 const styles = theme => ({
-	root: {
-		width: '100%',
-		marginTop: theme.spacing.unit * 3,
-		overflowX: 'auto',
-	},
-	table: {
-		minWidth: 700,
-	},
+  root: {
+    width: "100%",
+    marginTop: theme.spacing.unit * 3,
+    overflowX: "auto"
+  },
+  table: {
+    minWidth: 700
+  }
 });
 
 let id = 0;
 function createData(name, calories, fat, carbs, protein) {
-	id += 1;
-	return { id, name, calories, fat, carbs, protein };
+  id += 1;
+  return { id, name, calories, fat, carbs, protein };
 }
 
 const rows = [
-	createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
-	createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
-	createData('Eclair', 262, 16.0, 24, 6.0),
-	createData('Cupcake', 305, 3.7, 67, 4.3),
-	createData('Gingerbread', 356, 16.0, 49, 3.9),
+  createData("Frozen yoghurt", 159, 6.0, 24, 4.0),
+  createData("Ice cream sandwich", 237, 9.0, 37, 4.3),
+  createData("Eclair", 262, 16.0, 24, 6.0),
+  createData("Cupcake", 305, 3.7, 67, 4.3),
+  createData("Gingerbread", 356, 16.0, 49, 3.9)
 ];
-
-function Shipment(props) {
-	const { classes } = props;
-	// const handleFilter = () => {
-	// 	if(props.shipment && props.shipment.track === 1) {
-
-	// 	}
-	// }
-	return (
-		<TableRow>
-			<TableCell padding="checkbox">
-				<Checkbox />
-			</TableCell>
-			<TableCell align="right">{moment(props.shipment.lastUpdated).format("L h:mm a")}</TableCell>
-			<TableCell align="right">{props.shipment.status}</TableCell>
-			<TableCell align="right">{props.shipment.totalWeight}</TableCell>
-			<TableCell align="right">{props.shipment.dimensions}</TableCell>
-			<TableCell align="right">{props.shipment.productNames}</TableCell>
-
-			<TableCell align="right">
-				<ViewShipmentModal shipment={props.shipment} />
-			</TableCell>
-		</TableRow>
-	);
-}
-
-Shipment.propTypes = {
-	classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(Shipment);

--- a/src/components/shipment/ShipmentList.js
+++ b/src/components/shipment/ShipmentList.js
@@ -31,236 +31,627 @@ import FormGroup from "@material-ui/core/FormGroup";
 import EnhancedTableHead from "./table/EnhancedTableHead";
 import EnhancedTableToolbar from "./table/EnhancedTableToolbar";
 
-// class ShipmentList extends React.Component {
-// 	state = {
-// 		order: 'desc',
-// 		orderBy: 'shipDateUnix',
-// 		selected: [],
-// 		data: [],
-// 		page: 0,
-// 		rowsPerPage: 10,
-// 	};
-// 	componentDidMount() {
-// 		if (this.props.previousRowsPerPage) {
-// 			this.setState({
-// 				data: this.props.shipments,
-// 				page: this.props.previousPage,
-// 				rowsPerPage: this.props.previousRowsPerPage,
-// 			});
-// 		} else {
-// 			this.setState({ data: this.props.shipments });
-// 		}
-// 	}
-
-// 	handleRequestSort = (event, property) => {
-// 		const orderBy = property;
-// 		let order = 'desc';
-
-// 		if (this.state.orderBy === property && this.state.order === 'desc') {
-// 			order = 'asc';
-// 		}
-
-// 		this.setState({ order, orderBy });
-// 	};
-
-// 	handleSelectAllClick = event => {
-// 		if (event.target.checked) {
-// 			this.setState(state => ({ selected: state.data.map(n => n.uuid) }));
-// 			return;
-// 		}
-// 		this.setState({ selected: [] });
-// 	};
-
-// 	handleClick = (event, uuid) => {
-// 		const { selected } = this.state;
-// 		const selectedIndex = selected.indexOf(uuid);
-// 		let newSelected = [];
-
-// 		if (selectedIndex === -1) {
-// 			newSelected = newSelected.concat(selected, uuid);
-// 		} else if (selectedIndex === 0) {
-// 			newSelected = newSelected.concat(selected.slice(1));
-// 		} else if (selectedIndex === selected.length - 1) {
-// 			newSelected = newSelected.concat(selected.slice(0, -1));
-// 		} else if (selectedIndex > 0) {
-// 			newSelected = newSelected.concat(
-// 				selected.slice(0, selectedIndex),
-// 				selected.slice(selectedIndex + 1),
-// 			);
-// 		}
-
-// 		this.setState({ selected: newSelected });
-// 	};
-
-// 	handleChangePage = (event, page) => {
-// 		this.setState({ page });
-// 	};
-
-// 	handleChangeRowsPerPage = event => {
-// 		this.setState({ rowsPerPage: event.target.value });
-// 	};
-
-// 	isSelected = uuid => this.state.selected.indexOf(uuid) !== -1;
-
-// 	render() {
-// 		const { classes } = this.props;
-// 		const { data, order, orderBy, selected, rowsPerPage, page } = this.state;
-// 		const emptyRows =
-// 			rowsPerPage - Math.min(rowsPerPage, data.length - page * rowsPerPage);
-
-// 		return (
-// 			<Paper className={classes.root}>
-// 				<EnhancedTableToolbar
-// 					{...this.props}
-// 					currentPage={this.state.page}
-// 					currentRowsPerPage={this.state.rowsPerPage}
-// 					deleteShipment={this.props.deleteShipment}
-// 					selected={selected}
-// 					numSelected={selected.length}
-// 				/>
-// 				<div className={classes.tableWrapper}>
-// 					<Table className={classes.table} aria-labelledby="tableTitle">
-{
-  /* <EnhancedTableHead
-							shipments={this.props.shipments}
-							numSelected={selected.length}
-							order={order}
-							orderBy={orderBy}
-							onSelectAllClick={this.handleSelectAllClick}
-							onRequestSort={this.handleRequestSort}
-							rowCount={data.length}
-						/> */
-}
-// 						<TableBody>
-// 							{stableSort(data, getSorting(order, orderBy))
-// 								.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-// 								.map(n => {
-// 									const isSelected = this.isSelected(n.uuid);
-// 									const parsedStatus = () => {
-// 										if (n.status === 0) {
-// 											return 'Unknown';
-// 										}
-// 										if (n.status === 1) {
-// 											return 'Shipping';
-// 										}
-// 										if (n.status === 2) {
-// 											return 'En-Route';
-// 										}
-// 										if (n.status === 3) {
-// 											return 'Out-For-Delivery';
-// 										}
-// 										if (n.status === 4) {
-// 											return 'Delivered';
-// 										}
-// 										if (n.status === 5) {
-// 											return 'Delayed';
-// 										}
-// 									};
-// 									const statusStyling = () => {
-// 										if (n.status === 0) {
-// 											return {
-// 												backgroundColor: '#ffa9a8',
-// 												borderRadius: '25px',
-// 												paddingRight: '5px',
-// 											};
-// 										}
-// 										if (n.status === 1) {
-// 											return {
-// 												backgroundColor: '#ffc642',
-// 												borderRadius: '25px',
-// 												paddingRight: '5px',
-// 											};
-// 										}
-// 										if (n.status === 2) {
-// 											return {
-// 												backgroundColor: '#ffc642',
-// 												borderRadius: '25px',
-// 												paddingRight: '5px',
-// 											};
-// 										}
-// 										if (n.status === 3) {
-// 											return {
-// 												backgroundColor: '#ffc642',
-// 												borderRadius: '25px',
-// 												paddingRight: '5px',
-// 											};
-// 										}
-// 										if (n.status === 4) {
-// 											return {
-// 												backgroundColor: '#a7c2a6',
-// 												borderRadius: '25px',
-// 												paddingRight: '5px',
-// 											};
-// 										}
-// 										if (n.status === 5) {
-// 											return {
-// 												backgroundColor: '#ffa9a8',
-// 												borderRadius: '25px',
-// 												paddingRight: '5px',
-// 											};
-// 										}
-// 									};
-// 									return (
-// 										<TableRow
-// 											hover
-// 											role="checkbox"
-// 											aria-checked={isSelected}
-// 											tabIndex={-1}
-// 											key={n.uuid}
-// 											selected={isSelected}>
-// 											<TableCell padding="checkbox">
-// 												<Checkbox
-// 													onClick={event => this.handleClick(event, n.uuid)}
-// 													checked={isSelected}
-// 												/>
-// 											</TableCell>
-// 											<TableCell align="left">{n.dateShipped}</TableCell>
-// 											<TableCell align="left" style={statusStyling()}>
-// 												{parsedStatus()}
-// 											</TableCell>
-// 											<TableCell align="left">{n.shippedTo}</TableCell>
-// 											<TableCell align="left">
-// 												{n.productNames.join(', ')}
-// 											</TableCell>
-// 											<TableCell>
-// 												<div style={{ cursor: 'pointer' }}>
-// 													<ViewShipmentModal shipment={n} />
-// 												</div>
-// 											</TableCell>
-// 										</TableRow>
-// 									);
-// 								})}
-// 							{emptyRows > 0 && (
-// 								<TableRow style={{ height: 49 * emptyRows }}>
-// 									<TableCell colSpan={5} />
-// 								</TableRow>
-// 							)}
-// 						</TableBody>
-// 					</Table>
-// 				</div>
-// 				<TablePagination
-// 					rowsPerPageOptions={[5, 10, 25]}
-// 					component="div"
-// 					count={data.length}
-// 					rowsPerPage={rowsPerPage}
-// 					page={page}
-// 					backIconButtonProps={{
-// 						'aria-label': 'Previous Page',
-// 					}}
-// 					nextIconButtonProps={{
-// 						'aria-label': 'Next Page',
-// 					}}
-// 					onChangePage={this.handleChangePage}
-// 					onChangeRowsPerPage={this.handleChangeRowsPerPage}
-// 				/>
-// 			</Paper>
-// 		);
-// 	}
+// function desc(a, b, orderBy) {
+//   if (b[orderBy] < a[orderBy]) {
+//     return -1;
+//   }
+//   if (b[orderBy] > a[orderBy]) {
+//     return 1;
+//   }
+//   return 0;
 // }
 
-// ShipmentList.propTypes = {
-// 	classes: PropTypes.object.isRequired,
+// function stableSort(array, cmp) {
+//   const stabilizedThis = array.map((el, index) => [el, index]);
+//   stabilizedThis.sort((a, b) => {
+//     const order = cmp(a[0], b[0]);
+//     if (order !== 0) return order;
+//     return a[1] - b[1];
+//   });
+//   return stabilizedThis.map(el => el[0]);
+// }
+
+// function getSorting(order, orderBy) {
+//   return order === "desc"
+//     ? (a, b) => desc(a, b, orderBy)
+//     : (a, b) => -desc(a, b, orderBy);
+// }
+
+// const shipmentTitles = [
+//   {
+//     id: "shipDateUnix",
+//     numeric: false,
+//     disablePadding: true,
+//     label: "Date Shipped"
+//   },
+//   {
+//     id: "status",
+//     numeric: false,
+//     disablePadding: true,
+//     label: "Shipping Status"
+//   },
+//   {
+//     id: "shippedTo",
+//     numeric: true,
+//     disablePadding: false,
+//     label: "Shipped To"
+//   },
+//   {
+//     id: "productNames",
+//     numeric: false,
+//     disablePadding: true,
+//     label: "Included Products"
+//   },
+//   {
+//     id: "moreDetail",
+//     numeric: false,
+//     disablePadding: true,
+//     label: "More Detail"
+//   }
+// ];
+
+// class EnhancedTableHead extends React.Component {
+//   createSortHandler = (event, property) => {
+//     this.props.onRequestSort(event, property);
+//   };
+
+//   render() {
+//     const { onSelectAllClick, numSelected, rowCount } = this.props;
+
+//     return (
+//       <TableHead>
+//         <TableRow>
+//           <TableCell padding="checkbox">
+//             <Checkbox
+//               style={{ color: "#72BDA2" }}
+//               indeterminate={numSelected > 0 && numSelected < rowCount}
+//               checked={numSelected === rowCount}
+//               onChange={onSelectAllClick}
+//             />
+//           </TableCell>
+//           {shipmentTitles.map(
+//             shipment => (
+//               <TableCell
+//                 align="left"
+//                 padding="default"
+//                 onClick={event => this.createSortHandler(event, shipment.id)}
+//               >
+//                 <TableSortLabel>{shipment.label}</TableSortLabel>
+//               </TableCell>
+//             ),
+//             this
+//           )}
+//         </TableRow>
+//       </TableHead>
+//     );
+//   }
+// }
+
+// EnhancedTableHead.propTypes = {
+//   numSelected: PropTypes.number.isRequired,
+//   onRequestSort: PropTypes.func.isRequired,
+//   onSelectAllClick: PropTypes.func.isRequired,
+//   order: PropTypes.string.isRequired,
+//   orderBy: PropTypes.string.isRequired,
+//   rowCount: PropTypes.number.isRequired
 // };
+
+// const toolbarStyles = theme => ({
+//   root: {
+//     paddingRight: theme.spacing.unit
+//   },
+//   highlight:
+//     theme.palette.type === "light"
+//       ? {
+//           color: theme.palette.secondary.main,
+//           backgroundColor: lighten(theme.palette.secondary.light, 0.85)
+//         }
+//       : {
+//           color: theme.palette.text.primary,
+//           backgroundColor: theme.palette.secondary.dark
+//         },
+//   spacer: {
+//     flex: "1 1 100%"
+//   },
+//   actions: {
+//     color: theme.palette.text.secondary
+//   },
+//   title: {
+//     flex: "0 0 auto"
+//   }
+// });
+
+// let EnhancedTableToolbar = props => {
+//   const { numSelected, classes } = props;
+
+//   return (
+//     <Toolbar
+//       className={classNames(classes.root, {
+//         [classes.highlight]: numSelected > 0
+//       })}
+//     >
+//       <div className={classes.title}>
+//         {numSelected > 0 ? (
+//           <Typography color="inherit" variant="subtitle1">
+//             {numSelected} selected
+//           </Typography>
+//         ) : (
+//           <Typography variant="h6" id="tableTitle">
+//             Recent Shipments
+//           </Typography>
+//         )}
+//       </div>
+//       <div className={classes.spacer} />
+//       <div className={classes.actions}>
+//         {numSelected > 0 ? (
+//           <IconButton aria-label="Delete">
+//             <DeleteModal
+//               delete={() => {
+//                 props.deleteShipment(
+//                   props.selected,
+//                   props.currentPage,
+//                   props.currentRowsPerPage
+//                 );
+//               }}
+//             />
+//           </IconButton>
+//         ) : (
+//           <Tooltip title="Filter list">
+//             <IconButton aria-label="Filter list">
+//               <FilterListIcon />
+//             </IconButton>
+//           </Tooltip>
+//         )}
+//       </div>
+//     </Toolbar>
+//   );
+// };
+
+// EnhancedTableToolbar.propTypes = {
+//   classes: PropTypes.object.isRequired,
+//   numSelected: PropTypes.number.isRequired
+// };
+
+// EnhancedTableToolbar = withStyles(toolbarStyles)(EnhancedTableToolbar);
+
+// const styles = theme => ({
+//   root: {
+//     width: "auto"
+//   },
+//   table: {
+//     minWidth: 1020
+//   },
+//   tableWrapper: {
+//     overflowX: "auto"
+//   }
+// });
+
+// class ShipmentList extends React.Component {
+//   state = {
+//     order: "desc",
+//     orderBy: "shipDateUnix",
+//     selected: [],
+//     data: [],
+//     page: 0,
+//     rowsPerPage: 10
+//   };
+//   componentDidMount() {
+//     if (this.props.previousRowsPerPage) {
+//       this.setState({
+//         data: this.props.shipments,
+//         page: this.props.previousPage,
+//         rowsPerPage: this.props.previousRowsPerPage
+//       });
+//     } else {
+//       this.setState({ data: this.props.shipments });
+//     }
+//   }
+
+//   handleRequestSort = (event, property) => {
+//     const orderBy = property;
+//     let order = "desc";
+
+//     if (this.state.orderBy === property && this.state.order === "desc") {
+//       order = "asc";
+//     }
+
+//     this.setState({ order, orderBy });
+//   };
+
+//   handleSelectAllClick = event => {
+//     if (event.target.checked) {
+//       this.setState(state => ({ selected: state.data.map(n => n.uuid) }));
+//       return;
+//     }
+//     this.setState({ selected: [] });
+//   };
+
+//   handleClick = (event, uuid) => {
+//     const { selected } = this.state;
+//     const selectedIndex = selected.indexOf(uuid);
+//     let newSelected = [];
+
+//     if (selectedIndex === -1) {
+//       newSelected = newSelected.concat(selected, uuid);
+//     } else if (selectedIndex === 0) {
+//       newSelected = newSelected.concat(selected.slice(1));
+//     } else if (selectedIndex === selected.length - 1) {
+//       newSelected = newSelected.concat(selected.slice(0, -1));
+//     } else if (selectedIndex > 0) {
+//       newSelected = newSelected.concat(
+//         selected.slice(0, selectedIndex),
+//         selected.slice(selectedIndex + 1)
+//       );
+//     }
+
+//     this.setState({ selected: newSelected });
+//   };
+
+//   handleChangePage = (event, page) => {
+//     this.setState({ page });
+//   };
+
+//   handleChangeRowsPerPage = event => {
+//     this.setState({ rowsPerPage: event.target.value });
+//   };
+
+//   isSelected = uuid => this.state.selected.indexOf(uuid) !== -1;
+
+//   render() {
+//     const { classes } = this.props;
+//     const { data, order, orderBy, selected, rowsPerPage, page } = this.state;
+//     const emptyRows =
+//       rowsPerPage - Math.min(rowsPerPage, data.length - page * rowsPerPage);
+
+//     return (
+//       <Paper className={classes.root}>
+//         <EnhancedTableToolbar
+//           {...this.props}
+//           currentPage={this.state.page}
+//           currentRowsPerPage={this.state.rowsPerPage}
+//           deleteShipment={this.props.deleteShipment}
+//           selected={selected}
+//           numSelected={selected.length}
+//         />
+//         <div className={classes.tableWrapper}>
+//           <Table className={classes.table} aria-labelledby="tableTitle">
+//             <EnhancedTableHead
+//               shipments={this.props.shipments}
+//               numSelected={selected.length}
+//               order={order}
+//               orderBy={orderBy}
+//               onSelectAllClick={this.handleSelectAllClick}
+//               onRequestSort={this.handleRequestSort}
+//               rowCount={data.length}
+//             />
+//             <TableBody>
+//               {stableSort(data, getSorting(order, orderBy))
+//                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+//                 .map(n => {
+//                   const isSelected = this.isSelected(n.uuid);
+//                   const parsedStatus = () => {
+//                     if (n.status === 0) {
+//                       return "Unknown";
+//                     }
+//                     if (n.status === 1) {
+//                       return "Shipping";
+//                     }
+//                     if (n.status === 2) {
+//                       return "En-Route";
+//                     }
+//                     if (n.status === 3) {
+//                       return "Out-For-Delivery";
+//                     }
+//                     if (n.status === 4) {
+//                       return "Delivered";
+//                     }
+//                     if (n.status === 5) {
+//                       return "Delayed";
+//                     }
+//                   };
+//                   const statusStyling = () => {
+//                     if (n.status === 0) {
+//                       return {
+//                         backgroundColor: "#ffa9a8",
+//                         borderRadius: "25px",
+//                         paddingRight: "5px"
+//                       };
+//                     }
+//                     if (n.status === 1) {
+//                       return {
+//                         backgroundColor: "#ffc642",
+//                         borderRadius: "25px",
+//                         paddingRight: "5px"
+//                       };
+//                     }
+//                     if (n.status === 2) {
+//                       return {
+//                         backgroundColor: "#ffc642",
+//                         borderRadius: "25px",
+//                         paddingRight: "5px"
+//                       };
+//                     }
+//                     if (n.status === 3) {
+//                       return {
+//                         backgroundColor: "#ffc642",
+//                         borderRadius: "25px",
+//                         paddingRight: "5px"
+//                       };
+//                     }
+//                     if (n.status === 4) {
+//                       return {
+//                         backgroundColor: "#a7c2a6",
+//                         borderRadius: "25px",
+//                         paddingRight: "5px"
+//                       };
+//                     }
+//                     if (n.status === 5) {
+//                       return {
+//                         backgroundColor: "#ffa9a8",
+//                         borderRadius: "25px",
+//                         paddingRight: "5px"
+//                       };
+//                     }
+//                   };
+//                   return (
+//                     <TableRow
+//                       hover
+//                       role="checkbox"
+//                       aria-checked={isSelected}
+//                       tabIndex={-1}
+//                       key={n.uuid}
+//                       selected={isSelected}
+//                     >
+//                       <TableCell padding="checkbox">
+//                         <Checkbox
+//                           onClick={event => this.handleClick(event, n.uuid)}
+//                           checked={isSelected}
+//                         />
+//                       </TableCell>
+//                       <TableCell align="left">{n.dateShipped}</TableCell>
+//                       <TableCell align="left" style={statusStyling()}>
+//                         {parsedStatus()}
+//                       </TableCell>
+//                       <TableCell align="left">{n.shippedTo}</TableCell>
+//                       <TableCell align="left">
+//                         {n.productNames.join(", ")}
+//                       </TableCell>
+//                       <TableCell>
+//                         <div style={{ cursor: "pointer" }}>
+//                           <ViewShipmentModal shipment={n} />
+//                         </div>
+//                       </TableCell>
+//                     </TableRow>
+//                   );
+//                 })}
+//               {emptyRows > 0 && (
+//                 <TableRow style={{ height: 49 * emptyRows }}>
+//                   <TableCell colSpan={5} />
+//                 </TableRow>
+//               )}
+//             </TableBody>
+//           </Table>
+//         </div>
+//         <TablePagination
+//           rowsPerPageOptions={[5, 10, 25]}
+//           component="div"
+//           count={data.length}
+//           rowsPerPage={rowsPerPage}
+//           page={page}
+//           backIconButtonProps={{
+//             "aria-label": "Previous Page"
+//           }}
+//           nextIconButtonProps={{
+//             "aria-label": "Next Page"
+//           }}
+//           onChangePage={this.handleChangePage}
+//           onChangeRowsPerPage={this.handleChangeRowsPerPage}
+//         />
+//       </Paper>
+//     );
+//   }
+// }
+
+class ShipmentList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      order: "desc",
+      orderBy: "shipDateUnix",
+      selected: [],
+      data: [],
+      page: 0,
+      filter: true,
+      rowsPerPage: 10
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.previousRowsPerPage) {
+      this.setState({
+        data: this.props.shipments.filter(shipment => {
+          return shipment.tracked !== 1;
+        }),
+        page: this.props.previousPage,
+        rowsPerPage: this.props.previousRowsPerPage
+      });
+    } else {
+      console.log("settingState")
+      this.setState({ data: this.props.shipments.filter(shipment => {
+        return shipment.tracked !== 1;
+      }) });
+    }
+  }
+  
+  handleFilter = () => {
+    this.setState(
+      {
+        filter: this.state.filter === false ? true : false
+      },
+      () => this.handleRenderList()
+    );
+  };
+
+  handleRenderList = () => {
+    if (this.state.filter === false) {
+      this.setState(
+        {
+          data: this.props.shipments.filter(shipment => {
+            return shipment.tracked !== 0;
+          })
+        }
+      );
+    } else {
+      this.setState(
+        {
+          data: this.props.shipments.filter(shipment => {
+            return shipment.tracked !== 1;
+          })
+        }
+      );
+    }
+  };
+
+  handleRequestSort = (event, property) => {
+    const orderBy = property;
+    let order = "desc";
+
+    if (this.state.orderBy === property && this.state.order === "desc") {
+      order = "asc";
+    }
+
+    this.setState({ order, orderBy });
+  };
+
+  handleSelectAllClick = event => {
+    if (event.target.checked) {
+      this.setState(state => ({ selected: state.data.map(n => n.uuid) }));
+      return;
+    }
+    this.setState({ selected: [] });
+  };
+
+  handleClick = (event, uuid) => {
+    const { selected } = this.state;
+    const selectedIndex = selected.indexOf(uuid);
+    let newSelected = [];
+
+    if (selectedIndex === -1) {
+      newSelected = newSelected.concat(selected, uuid);
+    } else if (selectedIndex === 0) {
+      newSelected = newSelected.concat(selected.slice(1));
+    } else if (selectedIndex === selected.length - 1) {
+      newSelected = newSelected.concat(selected.slice(0, -1));
+    } else if (selectedIndex > 0) {
+      newSelected = newSelected.concat(
+        selected.slice(0, selectedIndex),
+        selected.slice(selectedIndex + 1)
+      );
+    }
+
+    this.setState({ selected: newSelected });
+  };
+
+  handleChangePage = (event, page) => {
+    this.setState({ page });
+  };
+
+  handleChangeRowsPerPage = event => {
+    this.setState({ rowsPerPage: event.target.value });
+  };
+
+  isSelected = uuid => this.state.selected.indexOf(uuid) !== -1;
+
+  render() {
+    const { classes } = this.props;
+    const { data, order, orderBy, selected, rowsPerPage, page } = this.state;
+    const emptyRows =
+      rowsPerPage - Math.min(rowsPerPage, data.length - page * rowsPerPage);
+    return (
+      <Paper className={classes.root}>
+        <FormGroup>
+          <FormControlLabel
+            control={<Switch onClick={() => this.handleFilter()} />}
+            label="See Tracked Packages"
+          />
+        </FormGroup>
+        <EnhancedTableToolbar
+          {...this.props}
+          filter={this.state.filter}
+          currentPage={this.state.page}
+          currentRowsPerPage={this.state.rowsPerPage}
+          deleteShipment={this.props.deleteShipment}
+          selected={selected}
+          numSelected={selected.length}
+        />
+        <div className={classes.tableWrapper}>
+          <Table className={classes.table}>
+            <EnhancedTableHead
+              shipments={this.props.shipments}
+              numSelected={selected.length}
+              order={order}
+              orderBy={orderBy}
+              onSelectAllClick={this.handleSelectAllClick}
+              onRequestSort={this.handleRequestSort}
+              rowCount={data.length}
+            />
+            <TableBody>
+              {/* {stableSort(data, getSorting(order, orderBy))
+                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                .map(shipment => {
+                  const isSelected = this.isSelected(shipment.uuid);
+                  return (
+                    <Shipment
+                      key={shipment.uuid}
+                      shipment={shipment}
+                      isSelected={isSelected}
+                      handleClick={this.handleClick}
+                    />
+                  );
+                })}
+              {emptyRows > 0 && (
+                <TableRow style={{ height: 49 * emptyRows }}>
+                  <TableCell colSpan={5} />
+                </TableRow>
+              )} */}
+              {this.state.data &&
+                this.state.data.map(shipment => {
+                  const isSelected = this.isSelected(shipment.uuid);
+                  return (
+                    <Shipment
+                      key={shipment.uuid}
+                      shipment={shipment}
+                      handleClick={this.handleClick}
+                      isSelected={isSelected}
+                    />
+                  );
+                })}
+            </TableBody>
+          </Table>
+        </div>
+        <TablePagination
+          rowsPerPageOptions={[5, 10, 25]}
+          component="div"
+          count={data.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          backIconButtonProps={{
+            "aria-label": "Previous Page"
+          }}
+          nextIconButtonProps={{
+            "aria-label": "Next Page"
+          }}
+          onChangePage={this.handleChangePage}
+          onChangeRowsPerPage={this.handleChangeRowsPerPage}
+        />
+      </Paper>
+    );
+  }
+}
+
+ShipmentList.propTypes = {
+  classes: PropTypes.object.isRequired
+};
 
 const styles = theme => ({
   root: {
@@ -273,71 +664,7 @@ const styles = theme => ({
   }
 });
 
-class ShipmentList extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      order: "desc",
-      orderBy: "shipDateUnix",
-      selected: [],
-      data: [],
-      page: 0,
-      rowsPerPage: 10
-    };
-  }
-
-  handleFilter = () => {
-    let trackedList = this.props.shipments.map(
-      shipment => shipment.tracked !== 0
-    );
-    return trackedList;
-  };
-
-  render() {
-    const { classes } = this.props;
-    const { data, order, orderBy, selected, rowsPerPage, page } = this.state;
-    const emptyRows =
-      rowsPerPage - Math.min(rowsPerPage, data.length - page * rowsPerPage);
-    return (
-      <Paper className={classes.root}>
-        <FormGroup>
-          <FormControlLabel
-            control={<Switch onClick={() => this.props.filter()} />}
-            label="See Tracked Packages"
-          />
-        </FormGroup>
-		<EnhancedTableToolbar
-					{...this.props}
-					currentPage={this.state.page}
-					currentRowsPerPage={this.state.rowsPerPage}
-					deleteShipment={this.props.deleteShipment}
-					selected={selected}
-					numSelected={selected.length}
-				/>
-				<div className={classes.tableWrapper}>
-        <Table className={classes.table}>
-          <EnhancedTableHead
-            shipments={this.props.shipments}
-            numSelected={selected.length}
-            order={order}
-            orderBy={orderBy}
-            onSelectAllClick={this.handleSelectAllClick}
-            onRequestSort={this.handleRequestSort}
-            rowCount={data.length}
-          />
-          {this.props.shipments &&
-            this.props.shipments.map(shipment => {
-              return <Shipment key={shipment.uuid} shipment={shipment} />;
-            })}
-          <TableBody />
-        </Table>
-		</div>
-      </Paper>
-    );
-  }
-}
-
-function desc(a, b, orderBy) {
+const desc = (a, b, orderBy) => {
   if (b[orderBy] < a[orderBy]) {
     return -1;
   }
@@ -345,9 +672,9 @@ function desc(a, b, orderBy) {
     return 1;
   }
   return 0;
-}
+};
 
-function stableSort(array, cmp) {
+const stableSort = (array, cmp) => {
   const stabilizedThis = array.map((el, index) => [el, index]);
   stabilizedThis.sort((a, b) => {
     const order = cmp(a[0], b[0]);
@@ -355,13 +682,13 @@ function stableSort(array, cmp) {
     return a[1] - b[1];
   });
   return stabilizedThis.map(el => el[0]);
-}
+};
 
-function getSorting(order, orderBy) {
+const getSorting = (order, orderBy) => {
   return order === "desc"
     ? (a, b) => desc(a, b, orderBy)
     : (a, b) => -desc(a, b, orderBy);
-}
+};
 
 export default compose(
   withRouter(

--- a/src/components/shipment/table/EnhancedTableHead.js
+++ b/src/components/shipment/table/EnhancedTableHead.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React from "react";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
@@ -9,112 +9,116 @@ import TableSortLabel from "@material-ui/core/TableSortLabel";
 import PropTypes from "prop-types";
 
 class EnhancedTableHead extends React.Component {
-	createSortHandler = (event, property) => {
-		this.props.onRequestSort(event, property);
-	};
+  createSortHandler = (event, property) => {
+    this.props.onRequestSort(event, property);
+  };
 
-	render() {
-		const { onSelectAllClick, numSelected, rowCount } = this.props;
+  render() {
+    const { onSelectAllClick, numSelected, rowCount } = this.props;
 
-		return (
-			<TableHead>
-				<TableRow>
-					<TableCell padding="checkbox">
-						<Checkbox
-							style={{ color: '#72BDA2' }}
-							indeterminate={numSelected > 0 && numSelected < rowCount}
-							checked={numSelected === rowCount}
-							onChange={onSelectAllClick}
-						/>
-					</TableCell>
-					{shipmentTitles.map(
-						shipment => (
-							<TableCell
-								align="right"
-								padding="default"
-								onClick={event => this.createSortHandler(event, shipment.id)}>
-								<TableSortLabel>{shipment.label}</TableSortLabel>
-							</TableCell>
-						),
-						this,
-					)}
-				</TableRow>
-			</TableHead>
-		);
-	}
+    return (
+      <TableHead>
+        <TableRow>
+          <TableCell padding="checkbox">
+            <Checkbox
+              style={{ color: "#72BDA2" }}
+              indeterminate={numSelected > 0 && numSelected < rowCount}
+              checked={numSelected === rowCount}
+              onChange={onSelectAllClick}
+            />
+          </TableCell>
+          {shipmentTitles.map(
+            (shipment, index) =>
+              index === 1 ? (
+                <TableCell
+                  align="center"
+                  padding="default"
+                  onClick={event => this.createSortHandler(event, shipment.id)}
+                >
+                  <TableSortLabel>{shipment.label}</TableSortLabel>
+                </TableCell>
+              ) : (
+                <TableCell
+                  align="right"
+                  padding="default"
+                  onClick={event => this.createSortHandler(event, shipment.id)}
+                >
+                  <TableSortLabel>{shipment.label}</TableSortLabel>
+                </TableCell>
+              ),
+            this
+          )}
+        </TableRow>
+      </TableHead>
+    );
+  }
 }
 
 EnhancedTableHead.propTypes = {
-	numSelected: PropTypes.number.isRequired,
-	onRequestSort: PropTypes.func.isRequired,
-	onSelectAllClick: PropTypes.func.isRequired,
-	order: PropTypes.string.isRequired,
-	orderBy: PropTypes.string.isRequired,
-	rowCount: PropTypes.number.isRequired,
+  numSelected: PropTypes.number.isRequired,
+  onRequestSort: PropTypes.func.isRequired,
+  onSelectAllClick: PropTypes.func.isRequired,
+  order: PropTypes.string.isRequired,
+  orderBy: PropTypes.string.isRequired,
+  rowCount: PropTypes.number.isRequired
 };
 
 const toolbarStyles = theme => ({
-	root: {
-		paddingRight: theme.spacing.unit,
-	},
-	highlight:
-		theme.palette.type === 'light'
-			? {
-					color: theme.palette.secondary.main,
-					backgroundColor: lighten(theme.palette.secondary.light, 0.85),
-			  }
-			: {
-					color: theme.palette.text.primary,
-					backgroundColor: theme.palette.secondary.dark,
-			  },
-	spacer: {
-		flex: '1 1 100%',
-	},
-	actions: {
-		color: theme.palette.text.secondary,
-	},
-	title: {
-		flex: '0 0 auto',
-	},
+  root: {
+    paddingRight: theme.spacing.unit
+  },
+  highlight:
+    theme.palette.type === "light"
+      ? {
+          color: theme.palette.secondary.main,
+          backgroundColor: lighten(theme.palette.secondary.light, 0.85)
+        }
+      : {
+          color: theme.palette.text.primary,
+          backgroundColor: theme.palette.secondary.dark
+        },
+  spacer: {
+    flex: "1 1 100%"
+  },
+  actions: {
+    color: theme.palette.text.secondary
+  },
+  title: {
+    flex: "0 0 auto"
+  }
 });
 
 const shipmentTitles = [
-	{
-		id: 'shipDateUnix',
-		numeric: false,
-		disablePadding: false,
-		label: 'Time Created',
-	},
-	{
-		id: 'status',
-		numeric: false,
-		disablePadding: false,
-		label: 'Status',
-	},
-	{
-		id: 'totalWeight',
-		numeric: false,
-		disablePadding: false,
-		label: 'Net Weight',
-	},
-	{
-		id: 'dimensions',
-		numeric: false,
-		disablePadding: false,
-		label: 'Dimensions (inches)',
-	},
-	{
-		id: 'productNames',
-		numeric: false,
-		disablePadding: false,
-		label: 'Product Names',
-	},
-	{
-		id: 'moreDetail',
-		numeric: false,
-		disablePadding: true,
-		label: '',
-	}
+  {
+    id: "shipDateUnix",
+    numeric: false,
+    disablePadding: false,
+    label: "Time Created"
+  },
+  {
+    id: "status",
+    numeric: false,
+    disablePadding: false,
+    label: "Status"
+  },
+  {
+    id: "totalWeight",
+    numeric: false,
+    disablePadding: false,
+    label: "Net Weight"
+  },
+  {
+    id: "dimensions",
+    numeric: false,
+    disablePadding: false,
+    label: "Dimensions (inches)"
+  },
+  {
+    id: "productNames",
+    numeric: false,
+    disablePadding: false,
+    label: "Product Names"
+  }
 ];
 
 export default EnhancedTableHead;

--- a/src/components/shipment/table/EnhancedTableToolbar.js
+++ b/src/components/shipment/table/EnhancedTableToolbar.js
@@ -42,6 +42,7 @@ let EnhancedTableToolbar = props => {
 									props.selected,
 									props.currentPage,
 									props.currentRowsPerPage,
+									props.filter
 								);
 							}}
 						/>

--- a/src/containers/dashboardView/DashboardView.js
+++ b/src/containers/dashboardView/DashboardView.js
@@ -18,8 +18,6 @@ const styles = theme => ({
 class DashboardView extends Component {
 	async componentDidMount() {
 		this.props.getProducts();
-		this.props.getShipments();
-		this.props.getPackages();
 	}
 
 	render() {
@@ -33,9 +31,6 @@ class DashboardView extends Component {
 					<div className="">
 						<ShipmentListView shipments={this.props.shipments} />
 					</div>
-					<div className="">
-						<PackageTableView shipments={this.props.packages} />
-					</div>
 				</div>
 			</div>
 		);
@@ -46,13 +41,12 @@ const mapStateToProps = state => {
 	return {
 		products: state.productsReducer.products,
 		shipments: state.shipmentsReducer.shipments,
-		packages: state.packageReducer.packages,
 	};
 };
 
 export default compose(
 	connect(
 		mapStateToProps,
-		{ getProducts, getShipments, getPackages },
+		{ getProducts, getShipments },
 	),
 )(withStyles(styles)(DashboardView));

--- a/src/containers/packageTableView/PackageTableView.js
+++ b/src/containers/packageTableView/PackageTableView.js
@@ -1,89 +1,89 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
-import { Redirect, Link } from 'react-router-dom';
+// import React, { Component } from 'react';
+// import { connect } from 'react-redux';
+// import { withStyles } from '@material-ui/core/styles';
+// import Typography from '@material-ui/core/Typography';
+// import Button from '@material-ui/core/Button';
+// import { Redirect, Link } from 'react-router-dom';
 
-import PackageList from '../../components/packageTable/PackageList';
+// import PackageList from '../../components/packageTable/PackageList';
 
-import { addShipment } from '../../store/actions/shipmentActions';
+// import { addShipment } from '../../store/actions/shipmentActions';
 
-import { getPackages, deletePackage } from '../../store/actions/packageActions';
+// import { getPackages, deletePackage } from '../../store/actions/packageActions';
 
-const styles = {
-	mainContainer: {
-		marginBottom: 60,
-		marginTop: 45,
-	},
-	heading: {
-		marginBottom: 40,
-	},
-};
+// const styles = {
+// 	mainContainer: {
+// 		marginBottom: 60,
+// 		marginTop: 45,
+// 	},
+// 	heading: {
+// 		marginBottom: 40,
+// 	},
+// };
 
-class PackageTableView extends Component {
-	state = {
-		previousPage: null,
-		previousRowsPerPage: null,
-	};
+// class PackageTableView extends Component {
+// 	state = {
+// 		previousPage: null,
+// 		previousRowsPerPage: null,
+// 	};
 
-	componentDidMount() {
-		this.props.getPackages();
-	}
+// 	componentDidMount() {
+// 		this.props.getPackages();
+// 	}
 
-	addShipment = (tracId, prodId) => {
-		this.props.addShipment(tracId, prodId);
-		return <Redirect to="/" />;
-	};
+// 	addShipment = (tracId, prodId) => {
+// 		this.props.addShipment(tracId, prodId);
+// 		return <Redirect to="/" />;
+// 	};
 
-	deletePackage = (uuid, currentPage, currentRowsPerPage) => {
-		this.setState(
-			{ previousPage: currentPage, previousRowsPerPage: currentRowsPerPage },
-			() => this.props.deletePackage(uuid.join()),
-		);
-		return <Redirect to="/" />;
-	};
+// 	deletePackage = (uuid, currentPage, currentRowsPerPage) => {
+// 		this.setState(
+// 			{ previousPage: currentPage, previousRowsPerPage: currentRowsPerPage },
+// 			() => this.props.deletePackage(uuid.join()),
+// 		);
+// 		return <Redirect to="/" />;
+// 	};
 
-	render() {
-		const { classes } = this.props;
-		return (
-			<div className={classes.mainContainer}>
-				<Typography
-					className={classes.heading}
-					gutterBottom
-					variant="h5"
-					component="h2">
-					Packages
-				</Typography>
-				{this.props.packages.length > 0 ? (
-					<div>
-						<PackageList
-							previousPage={this.state.previousPage}
-							previousRowsPerPage={this.state.previousRowsPerPage}
-							deletePackage={this.deletePackage}
-							packages={this.props.packages}
-						/>
-					</div>
-				) : (
-					<PackageList
-						previousPage={this.state.previousPage}
-						previousRowsPerPage={this.state.previousRowsPerPage}
-						deletePackage={this.deletePackage}
-						packages={this.props.packages}
-					/>
-				)}
-			</div>
-		);
-	}
-}
+// 	render() {
+// 		const { classes } = this.props;
+// 		return (
+// 			<div className={classes.mainContainer}>
+// 				<Typography
+// 					className={classes.heading}
+// 					gutterBottom
+// 					variant="h5"
+// 					component="h2">
+// 					Packages
+// 				</Typography>
+// 				{this.props.packages.length > 0 ? (
+// 					<div>
+// 						<PackageList
+// 							previousPage={this.state.previousPage}
+// 							previousRowsPerPage={this.state.previousRowsPerPage}
+// 							deletePackage={this.deletePackage}
+// 							packages={this.props.packages}
+// 						/>
+// 					</div>
+// 				) : (
+// 					<PackageList
+// 						previousPage={this.state.previousPage}
+// 						previousRowsPerPage={this.state.previousRowsPerPage}
+// 						deletePackage={this.deletePackage}
+// 						packages={this.props.packages}
+// 					/>
+// 				)}
+// 			</div>
+// 		);
+// 	}
+// }
 
-const mapStateToProps = state => {
-	return {
-		packages: state.packageReducer.packages,
-	};
-};
+// const mapStateToProps = state => {
+// 	return {
+// 		packages: state.packageReducer.packages,
+// 	};
+// };
 
-export default connect(
-	mapStateToProps,
-	{ getPackages, deletePackage, addShipment },
-)(withStyles(styles)(PackageTableView));
+// export default connect(
+// 	mapStateToProps,
+// 	{ getPackages, deletePackage, addShipment },
+// )(withStyles(styles)(PackageTableView));

--- a/src/containers/shipmentView/ShipmentListView.js
+++ b/src/containers/shipmentView/ShipmentListView.js
@@ -1,128 +1,103 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
-import { Redirect, Link } from 'react-router-dom';
-
-import ShipmentList from '../../components/shipment/ShipmentList';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+import { Redirect, Link } from "react-router-dom";
+import ShipmentList from "../../components/shipment/ShipmentList";
 import {
-	getShipments,
-	addShipment,
-	deleteShipment,
-} from '../../store/actions/shipmentActions';
+  getShipments,
+  addShipment,
+  deleteShipment,
+  deletePackage
+} from "../../store/actions/shipmentActions";
+
 
 const styles = {
-	mainContainer: {
-		marginTop: 45,
-		marginBottom: 60,
-	},
-	heading: {
-		marginBottom: 40,
-	},
+  mainContainer: {
+    marginTop: 45,
+    marginBottom: 60
+  },
+  heading: {
+    marginBottom: 40
+  }
 };
 
 class ShipmentListView extends Component {
-	state = {
-		previousPage: null,
-		previousRowsPerPage: null,
-		filter: true,
-		filteredList: [],
-	};
+  state = {
+    previousPage: null,
+    previousRowsPerPage: null,
+    filter: true,
+    filteredList: []
+  };
 
-	handleFilter = () => {
-		this.setState(
-			{
-				filter: this.state.filter === false ? true : false,
-			},
-			() => this.handleRenderList(),
-		);
-	};
+  componentDidMount() {
+    this.props.getShipments();
+  }
 
-	handleRenderList = () => {
-		if (this.state.filter === false) {
-			this.setState(
-				{
-					filteredList: this.props.shipments.filter(shipment => {
-						return shipment.tracked !== 0;
-					}),
-				},
-				() => console.log(this.state.filteredList),
-			);
-		} else {
-			this.setState(
-				{
-					filteredList: this.props.shipments.filter(shipment => {
-						return shipment.tracked !== 1;
-					}),
-				},
-				() => console.log(this.state.filteredList),
-			);
-		}
-	};
+  addShipment = (tracId, prodId) => {
+    this.props.addShipment(tracId, prodId);
+    return <Redirect to="/" />;
+  };
 
-	componentDidMount() {
-		this.props.getShipments();
-		this.setState({ filteredList: this.props.shipments });
-	}
+  deleteShipment = (uuid, currentPage, currentRowsPerPage, filter) => {
+    if (filter === false) {
+      this.setState(
+        { previousPage: currentPage, previousRowsPerPage: currentRowsPerPage },
+        () => this.props.deleteShipment(uuid.join())
+      );
+      return <Redirect to="/" />;
+    } else {
+      this.setState(
+        { previousPage: currentPage, previousRowsPerPage: currentRowsPerPage },
+        () => this.props.deletePackage(uuid.join())
+      );
+    }
+  };
 
-	addShipment = (tracId, prodId) => {
-		this.props.addShipment(tracId, prodId);
-		return <Redirect to="/" />;
-	};
-
-	deleteShipment = (uuid, currentPage, currentRowsPerPage) => {
-		this.setState(
-			{ previousPage: currentPage, previousRowsPerPage: currentRowsPerPage },
-			() => this.props.deleteShipment(uuid.join()),
-		);
-		return <Redirect to="/" />;
-	};
-
-	render() {
-		const { classes } = this.props;
-		return (
-			<div className={classes.mainContainer}>
-				<Typography
-					className={classes.heading}
-					gutterBottom
-					variant="h5"
-					component="h2">
-					Shipments
-				</Typography>
-				{this.props.shipments.length > 0 ? (
-					<div>
-						<ShipmentList
-							filter={this.handleFilter}
-							previousPage={this.state.previousPage}
-							previousRowsPerPage={this.state.previousRowsPerPage}
-							addShipment={this.addShipment}
-							deleteShipment={this.deleteShipment}
-							shipments={this.state.filteredList}
-						/>
-					</div>
-				) : (
-					<ShipmentList
-						filter={this.handleFilter}
-						previousPage={this.state.previousPage}
-						previousRowsPerPage={this.state.previousRowsPerPage}
-						addShipment={this.addShipment}
-						deleteShipment={this.deleteShipment}
-						shipments={this.state.filteredList}
-					/>
-				)}
-			</div>
-		);
-	}
+  render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.mainContainer}>
+        <Typography
+          className={classes.heading}
+          gutterBottom
+          variant="h5"
+          component="h2"
+        >
+          Shipments
+        </Typography>
+        {this.props.shipments.length > 0 ? (
+          <div>
+            <ShipmentList
+              previousPage={this.state.previousPage}
+              previousRowsPerPage={this.state.previousRowsPerPage}
+              addShipment={this.addShipment}
+              deleteShipment={this.deleteShipment}
+              shipments={this.props.shipments}
+            />
+          </div>
+        ) : (
+          <ShipmentList
+            previousPage={this.state.previousPage}
+            previousRowsPerPage={this.state.previousRowsPerPage}
+            addShipment={this.addShipment}
+            deleteShipment={this.deleteShipment}
+            shipments={this.props.shipments}
+          />
+        )}
+      </div>
+    );
+  }
 }
 
 const mapStateToProps = state => {
-	return {
-		shipments: state.shipmentsReducer.shipments,
-	};
+  return {
+    shipments: state.shipmentsReducer.shipments
+  };
 };
 
 export default connect(
-	mapStateToProps,
-	{ getShipments, addShipment, deleteShipment },
+  mapStateToProps,
+  { getShipments, addShipment, deleteShipment, deletePackage }
 )(withStyles(styles)(ShipmentListView));

--- a/src/hoc/layout/Layout.js
+++ b/src/hoc/layout/Layout.js
@@ -1,233 +1,238 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { withStyles } from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
-import Drawer from '@material-ui/core/Drawer';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import AccountCircle from '@material-ui/icons/AccountCircle';
-import Button from '@material-ui/core/Button';
-import { withRouter } from 'react-router-dom';
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { withStyles } from "@material-ui/core/styles";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import Drawer from "@material-ui/core/Drawer";
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+import AccountCircle from "@material-ui/icons/AccountCircle";
+import Button from "@material-ui/core/Button";
+import { withRouter } from "react-router-dom";
 
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
-import IconButton from '@material-ui/core/IconButton';
+import Typography from "@material-ui/core/Typography";
+import Divider from "@material-ui/core/Divider";
+import IconButton from "@material-ui/core/IconButton";
 
-import MenuIcon from '@material-ui/icons/Menu';
-import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import Avatar from '@material-ui/core/Avatar';
+import MenuIcon from "@material-ui/icons/Menu";
+import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
+import Avatar from "@material-ui/core/Avatar";
 
-import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { addPackage } from '../../store/actions/packageActions';
-import LoggedInLinks from '../../components/navigation/LoggedInLinks';
-import LoggedOutLinks from '../../components/navigation/LoggedOutLinks';
+import { connect } from "react-redux";
+import { compose } from "redux";
+import { addPackage } from "../../store/actions/packageActions";
+import LoggedInLinks from "../../components/navigation/LoggedInLinks";
+import LoggedOutLinks from "../../components/navigation/LoggedOutLinks";
 
 const drawerWidth = 185;
 
 const styles = theme => ({
-	root: {
-		display: 'flex',
-		margin: '0 auto',
-	},
-	toolbar: {
-		paddingRight: 24,
-	},
-	toolbarIcon: {
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'flex-end',
-		padding: '0 8px',
-		...theme.mixins.toolbar,
-	},
-	appBar: {
-		right: 'auto',
-		maxWidth: 1200,
-		backgroundColor: '#F2F3F4',
-		zIndex: theme.zIndex.drawer + 1,
-		transition: theme.transitions.create(['width', 'margin'], {
-			easing: theme.transitions.easing.sharp,
-			duration: theme.transitions.duration.leavingScreen,
-		}),
-	},
-	appBarShift: {
-		marginLeft: drawerWidth,
-		width: `calc(100% - ${drawerWidth}px)`,
-		transition: theme.transitions.create(['width', 'margin'], {
-			easing: theme.transitions.easing.sharp,
-			duration: theme.transitions.duration.enteringScreen,
-		}),
-	},
-	menuButton: {
-		marginLeft: 12,
-		marginRight: 36,
-		color: '#72BDA2',
-	},
-	menuButtonHidden: {
-		display: 'none',
-	},
-	title: {
-		flexGrow: 1,
-	},
-	drawerPaper: {
-		margin: '0 auto',
-		position: 'relative',
-		whiteSpace: 'nowrap',
-		width: drawerWidth,
-		transition: theme.transitions.create('width', {
-			easing: theme.transitions.easing.sharp,
-			duration: theme.transitions.duration.enteringScreen,
-		}),
-	},
-	drawerPaperClose: {
-		overflowX: 'hidden',
-		transition: theme.transitions.create('width', {
-			easing: theme.transitions.easing.sharp,
-			duration: theme.transitions.duration.leavingScreen,
-		}),
-		width: theme.spacing.unit * 7,
-		[theme.breakpoints.up('sm')]: {
-			width: theme.spacing.unit * 9,
-		},
-	},
-	appBarSpacer: theme.mixins.toolbar,
-	content: {
-		marginTop: 50,
-		flexGrow: 1,
-		padding: theme.spacing.unit * 3,
-		height: '100vh',
-		overflow: 'auto',
-	},
-	chartContainer: {
-		marginLeft: -22,
-	},
-	tableContainer: {
-		height: 320,
-	},
-	h5: {
-		marginBottom: theme.spacing.unit * 2,
-	},
+  root: {
+    display: "flex",
+    margin: "0 auto"
+  },
+  toolbar: {
+    paddingRight: 24
+  },
+  toolbarIcon: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    padding: "0 8px",
+    ...theme.mixins.toolbar
+  },
+  appBar: {
+    right: "auto",
+    maxWidth: 1200,
+    backgroundColor: "#F2F3F4",
+    zIndex: theme.zIndex.drawer + 1,
+    transition: theme.transitions.create(["width", "margin"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen
+    })
+  },
+  appBarShift: {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(["width", "margin"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen
+    })
+  },
+  menuButton: {
+    marginLeft: 12,
+    marginRight: 36,
+    color: "#72BDA2"
+  },
+  menuButtonHidden: {
+    display: "none"
+  },
+  title: {
+    flexGrow: 1
+  },
+  drawerPaper: {
+    margin: "0 auto",
+    position: "relative",
+    whiteSpace: "nowrap",
+    width: drawerWidth,
+    transition: theme.transitions.create("width", {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen
+    })
+  },
+  drawerPaperClose: {
+    overflowX: "hidden",
+    transition: theme.transitions.create("width", {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen
+    }),
+    width: theme.spacing.unit * 7,
+    [theme.breakpoints.up("sm")]: {
+      width: theme.spacing.unit * 9
+    }
+  },
+  appBarSpacer: theme.mixins.toolbar,
+  content: {
+    marginTop: 50,
+    flexGrow: 1,
+    padding: theme.spacing.unit * 3,
+    height: "100vh",
+    overflow: "auto"
+  },
+  chartContainer: {
+    marginLeft: -22
+  },
+  tableContainer: {
+    height: 320
+  },
+  h5: {
+    marginBottom: theme.spacing.unit * 2
+  }
 });
 
 class Layout extends React.Component {
-	state = {
-		open: true,
-	};
+  state = {
+    open: true
+  };
 
-	handleDrawerOpen = () => {
-		this.setState({ open: true });
-	};
+  handleDrawerOpen = () => {
+    this.setState({ open: true });
+  };
 
-	handleDrawerClose = () => {
-		this.setState({ open: false });
-	};
+  handleDrawerClose = () => {
+    this.setState({ open: false });
+  };
 
-	componentDidMount() {
-		setTimeout(() => {
-			this.setState({
-				open: false,
-			});
-		}, 1000);
-	}
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        open: false
+      });
+    }, 1000);
+  }
 
-	render() {
-		const { classes } = this.props;
+  render() {
+    const { classes } = this.props;
 
-		return (
-			<div className={classes.root}>
-				<CssBaseline />
-				<AppBar
-					position="absolute"
-					className={classNames(
-						classes.appBar,
-						this.state.open && classes.appBarShift,
-					)}>
-					<Toolbar
-						disableGutters={!this.state.open}
-						className={classes.toolbar}>
-						<IconButton
-							color="inherit"
-							aria-label="Open drawer"
-							onClick={this.handleDrawerOpen}
-							className={classNames(
-								classes.menuButton,
-								this.state.open && classes.menuButtonHidden,
-							)}>
-							<MenuIcon />
-						</IconButton>
-						<Typography
-							onClick={() => this.props.history.push('/')}
-							component="h1"
-							variant="h6"
-							color="inherit"
-							noWrap
-							className={classes.title}>
-							<Button style={{ color: '#0D2C54' }}>
-								<Typography color="inherit" variant="h6">
-									ScannAR
-								</Typography>
-							</Button>
-						</Typography>
-						{this.props.isLoggedIn ? (
-							<Avatar
-								alt={this.props.userInfo.displayName}
-								src={this.props.userInfo.photoURL}
-								className={classes.avatar}
-							/>
-						) : (
-							<AccountCircle />
-						)}
-					</Toolbar>
-				</AppBar>
-				<Drawer
-					variant="permanent"
-					classes={{
-						paper: classNames(
-							classes.drawerPaper,
-							!this.state.open && classes.drawerPaperClose,
-						),
-					}}
-					open={this.state.open}>
-					<div className={classes.toolbarIcon}>
-						<IconButton onClick={this.handleDrawerClose}>
-							<ChevronLeftIcon />
-						</IconButton>
-					</div>
-					<Divider />
-					{this.props.isLoggedIn ? (
-						<LoggedInLinks
-							addPackage={this.props.addPackage}
-							handleDrawerOpen={this.handleDrawerOpen}
-							selectedProducts={this.props.selectedProducts}
-						/>
-					) : (
-						<LoggedOutLinks />
-					)}
-				</Drawer>
-				<main className={classes.content}>{this.props.children}</main>
-			</div>
-		);
-	}
+    return (
+      <div className={classes.root}>
+        <CssBaseline />
+        <AppBar
+          position="absolute"
+          className={classNames(
+            classes.appBar,
+            this.state.open && classes.appBarShift
+          )}
+        >
+          <Toolbar
+            disableGutters={!this.state.open}
+            className={classes.toolbar}
+          >
+            <IconButton
+              color="inherit"
+              aria-label="Open drawer"
+              onClick={this.handleDrawerOpen}
+              className={classNames(
+                classes.menuButton,
+                this.state.open && classes.menuButtonHidden
+              )}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography
+              onClick={() => this.props.history.push("/")}
+              component="h1"
+              variant="h6"
+              color="inherit"
+              noWrap
+              className={classes.title}
+            >
+              <Button style={{ color: "#0D2C54" }}>
+                <Typography color="inherit" variant="h6">
+                  ScannAR
+                </Typography>
+              </Button>
+            </Typography>
+            {this.props.isLoggedIn ? (
+              <Avatar
+                alt={this.props.userInfo.displayName}
+                src={this.props.userInfo.photoURL}
+                className={classes.avatar}
+              />
+            ) : (
+              <AccountCircle />
+            )}
+          </Toolbar>
+        </AppBar>
+        <Drawer
+          variant="permanent"
+          classes={{
+            paper: classNames(
+              classes.drawerPaper,
+              !this.state.open && classes.drawerPaperClose
+            )
+          }}
+          open={this.state.open}
+        >
+          <div className={classes.toolbarIcon}>
+            <IconButton onClick={this.handleDrawerClose}>
+              <ChevronLeftIcon />
+            </IconButton>
+          </div>
+          <Divider />
+          {this.props.isLoggedIn ? (
+            <LoggedInLinks
+              addPackage={this.props.addPackage}
+              handleDrawerOpen={this.handleDrawerOpen}
+              selectedProducts={this.props.selectedProducts}
+            />
+          ) : (
+            <LoggedOutLinks />
+          )}
+        </Drawer>
+        <main className={classes.content}>{this.props.children}</main>
+      </div>
+    );
+  }
 }
 
 const mapStateToProps = state => {
-	return {
-		isLoggedIn: state.userReducer.isLoggedIn,
-		userInfo: state.firebaseReducer.auth,
-		selectedProducts: state.packageReducer.selectedProducts,
-	};
+  return {
+    isLoggedIn: state.userReducer.isLoggedIn,
+    userInfo: state.firebaseReducer.auth,
+    selectedProducts: state.packageReducer.selectedProducts
+  };
 };
 
 Layout.propTypes = {
-	classes: PropTypes.object.isRequired,
+  classes: PropTypes.object.isRequired
 };
 
 export default compose(
-	withRouter(
-		connect(
-			mapStateToProps,
-			{ addPackage },
-		)(withStyles(styles)(Layout)),
-	),
+  withRouter(
+    connect(
+      mapStateToProps,
+      { addPackage }
+    )(withStyles(styles)(Layout))
+  )
 );

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -35,10 +35,8 @@ class Routes extends Component {
 				<Switch>
 					<Redirect from="/auth" to="/" />
 					<Route exact path="/logout" component={LogoutView} />
-
 					<Route exact path="/shipments" component={ShipmentListView} />
 					<Route exact path="/packaging" component={PackagingView} />
-					<Route exact path="/packages" component={PackageTableView} />
 					<Route exact path="/products" component={ProductListView} />
 					<Route exact path="/account" component={AccountView} />
 					<Route exact path="/" component={DashboardView} />

--- a/src/store/actions/packageActions.js
+++ b/src/store/actions/packageActions.js
@@ -10,10 +10,6 @@ export const ADDING_PACKAGE = 'ADDING_PACKAGE';
 export const ADDING_PACKAGE_SUCCESSFUL = 'ADDING_PACKAGE_SUCCESSFUL';
 export const ADDING_PACKAGE_FAILURE = 'ADDING_PACKAGE_FAILURE';
 
-export const DELETING_PACKAGE = 'DELETING_PACKAGE';
-export const DELETING_PACKAGE_SUCCESSFUL = 'DELETING_PACKAGE_SUCCESSFUL';
-export const DELETING_PACKAGE_FAILURE = 'DELETING_PACKAGE_FAILURE';
-
 axios.defaults.baseURL = 'https://scannarserver.herokuapp.com/api';
 axios.interceptors.request.use(
 	function(options) {
@@ -53,18 +49,6 @@ export const addPackage = packageArr => dispatch => {
 		)
 		.catch(err =>
 			dispatch({ type: ADDING_PACKAGE_FAILURE, payload: err.data }),
-		);
-};
-
-export const deletePackage = uuid => dispatch => {
-	dispatch({ type: DELETING_PACKAGE });
-	axios
-		.delete(`/packaging/delete/${uuid}`)
-		.then(res =>
-			dispatch({ type: DELETING_PACKAGE_SUCCESSFUL, payload: res.data }),
-		)
-		.catch(err =>
-			dispatch({ type: DELETING_PACKAGE_FAILURE, payload: err.data }),
 		);
 };
 

--- a/src/store/actions/shipmentActions.js
+++ b/src/store/actions/shipmentActions.js
@@ -12,6 +12,10 @@ export const DELETING_SHIPMENT = 'DELETING_SHIPMENT';
 export const DELETING_SHIPMENT_SUCCESSFUL = 'DELETING_SHIPMENT_SUCCESSFUL';
 export const DELETING_SHIPMENT_FAILURE = 'DELETING_SHIPMENT_FAILURE';
 
+export const DELETING_PACKAGE = 'DELETING_PACKAGE';
+export const DELETING_PACKAGE_SUCCESSFUL = 'DELETING_PACKAGE_SUCCESSFUL';
+export const DELETING_PACKAGE_FAILURE = 'DELETING_PACKAGE_FAILURE';
+
 export const addShipment = (trackingNumber, productId) => dispatch => {
 	const trackingRequest = {
 		trackingNumber,
@@ -44,11 +48,23 @@ export const getShipments = () => dispatch => {
 export const deleteShipment = uuid => dispatch => {
 	dispatch({ type: DELETING_SHIPMENT });
 	axios
-		.delete(`/shipments/delete/${uuid}`, uuid)
+		.delete(`/shipments/deleteweb/${uuid}`)
 		.then(res =>
 			dispatch({ type: DELETING_SHIPMENT_SUCCESSFUL, payload: res.data }),
 		)
 		.catch(err =>
 			dispatch({ type: DELETING_SHIPMENT_FAILURE, payload: err.data }),
+		);
+};
+
+export const deletePackage = uuid => dispatch => {
+	dispatch({ type: DELETING_PACKAGE });
+	axios
+		.delete(`/packaging/deleteweb/${uuid}`)
+		.then(res =>
+			dispatch({ type: DELETING_PACKAGE_SUCCESSFUL, payload: res.data }),
+		)
+		.catch(err =>
+			dispatch({ type: DELETING_PACKAGE_FAILURE, payload: err.data }),
 		);
 };

--- a/src/store/reducers/packageReducer.js
+++ b/src/store/reducers/packageReducer.js
@@ -5,13 +5,11 @@ import {
 	ADDING_PACKAGE,
 	ADDING_PACKAGE_SUCCESSFUL,
 	ADDING_PACKAGE_FAILURE,
-	DELETING_PACKAGE,
-	DELETING_PACKAGE_SUCCESSFUL,
-	DELETING_PACKAGE_FAILURE,
 	SELECTED_PRODUCT,
 } from '../actions/packageActions';
 
 const initialState = {
+	shipments: [],
 	packages: [],
 	data: [],
 	addedPackages: [],
@@ -83,40 +81,6 @@ const packageReducer = (state = initialState, action) => {
 			return {
 				...state,
 				fetching: false,
-				success: false,
-				failure: true,
-				error: action.payload,
-			};
-		case DELETING_PACKAGE:
-			return {
-				...state,
-				fetching: false,
-				adding: false,
-				editing: false,
-				deleting: true,
-				success: false,
-				failure: false,
-				error: null,
-			};
-		case DELETING_PACKAGE_SUCCESSFUL:
-			return {
-				...state,
-				packages: action.payload,
-				fetching: false,
-				adding: false,
-				editing: false,
-				deleting: false,
-				success: true,
-				failure: false,
-				error: null,
-			};
-		case DELETING_PACKAGE_FAILURE:
-			return {
-				...state,
-				fetching: false,
-				adding: false,
-				editing: false,
-				deleting: false,
 				success: false,
 				failure: true,
 				error: action.payload,

--- a/src/store/reducers/shipmentsReducer.js
+++ b/src/store/reducers/shipmentsReducer.js
@@ -8,6 +8,9 @@ import {
 	DELETING_SHIPMENT,
 	DELETING_SHIPMENT_SUCCESSFUL,
 	DELETING_SHIPMENT_FAILURE,
+	DELETING_PACKAGE,
+	DELETING_PACKAGE_SUCCESSFUL,
+	DELETING_PACKAGE_FAILURE,
 } from '../actions/shipmentActions';
 
 import moment from "moment"
@@ -116,7 +119,41 @@ const shipmentsReducer = (state = initialState, action) => {
 				failure: true,
 				error: action.payload,
 			};
-
+			case DELETING_PACKAGE:
+			return {
+				...state,
+				shipments: [],
+				fetching: false,
+				adding: false,
+				editing: false,
+				deleting: true,
+				success: false,
+				failure: false,
+				error: null,
+			};
+		case DELETING_PACKAGE_SUCCESSFUL:
+			return {
+				...state,
+				shipments: action.payload.map(shipment => {shipment.shipDateUnix = moment(shipment.lastUpdated).format('x'); return shipment}),
+				fetching: false,
+				adding: false,
+				editing: false,
+				deleting: false,
+				success: true,
+				failure: false,
+				error: null,
+			};
+		case DELETING_PACKAGE_FAILURE:
+			return {
+				...state,
+				fetching: false,
+				adding: false,
+				editing: false,
+				deleting: false,
+				success: false,
+				failure: true,
+				error: action.payload,
+			};
 		default:
 			return state;
 	}


### PR DESCRIPTION
Moved filter logic into the shipments list component to allow for complete rerendering of the shipments table. Moved packaging deletion logic into the shipments reducer/actions to allow packages/shipments to share redux store state.shipmentsReducer.shipments. If this wasn't done, packages and shipments would be affecting different instances of redux shipments store.