### PR TITLE
Shipments modals updates - tracking numbers can now be added through UI

### DIFF
--- a/src/components/modals/ViewShipmentModal.js
+++ b/src/components/modals/ViewShipmentModal.js
@@ -81,7 +81,7 @@ const ViewShipmentModal = props => {
                 Suggested Packaging Orientation
               </Typography>
               <EmbeddedModel source={props.shipment.modelURL} />
-              <form onSubmit={() => props.closeModal()} className={classes.trackForm} autocomplete="off">
+              <form onSubmit={(e) => props.submitTracking(e, props.shipment.uuid)} className={classes.trackForm} autocomplete="off">
               <TextField className={classes.trackInput} placeholder="Enter USPS Tracking Number..." name="trackingNumber" value={props.trackingNumber} onChange={props.handleChanges}/>
               <Button type="submit" className={classes.trackButton}>Track it!</Button>
               </form>

--- a/src/components/shipment/ShipmentList.js
+++ b/src/components/shipment/ShipmentList.js
@@ -41,7 +41,7 @@ const styles = theme => ({
     minWidth: 700
   },
   switch: {
-    margin: "0px 20px 0",
+    margin: "0px 20px 0"
   }
 });
 
@@ -56,51 +56,54 @@ class ShipmentList extends React.Component {
       page: 0,
       filter: true,
       rowsPerPage: 10,
-      modal: false
+      modal: false,
+      trackingNumber: ""
     };
   }
 
   componentDidMount() {
     if (this.props.previousRowsPerPage) {
       if (this.props.previousFilter) {
-      this.setState({
-        data: this.props.shipments
-          .filter(shipment => {
+        this.setState({
+          data: this.props.shipments.filter(shipment => {
             return shipment.tracked !== 1;
           }),
-        filter: this.props.previousFilter,
-        page: this.props.previousPage,
-        rowsPerPage: this.props.previousRowsPerPage
-      })}
-      else {
-        this.setState({
-          data: this.props.shipments
-            .filter(shipment => {
-              return shipment.tracked !== 0;
-            }),
           filter: this.props.previousFilter,
           page: this.props.previousPage,
           rowsPerPage: this.props.previousRowsPerPage
-        })
+        });
+      } else {
+        this.setState({
+          data: this.props.shipments.filter(shipment => {
+            return shipment.tracked !== 0;
+          }),
+          filter: this.props.previousFilter,
+          page: this.props.previousPage,
+          rowsPerPage: this.props.previousRowsPerPage
+        });
       }
     } else {
       this.setState({
-        data: this.props.shipments
-          .filter(shipment => {
-            return shipment.tracked !== 1;
-          })
-          
+        data: this.props.shipments.filter(shipment => {
+          return shipment.tracked !== 1;
+        })
       });
     }
   }
 
-  openModal = (shipmentData) => {
-    this.setState({ modal: shipmentData });
-	};
+  submitTracking = (e, uuid) => {
+    e.preventDefault();
+    const trackingSubmission = this.state.trackingNumber.slice()
+    this.setState({ modal: false, trackingNumber: "" }, () => this.props.addShipment(trackingSubmission, uuid))
+  }
 
-	closeModal = () => {
-		this.setState({ modal: false });
-	};
+  openModal = shipmentData => {
+    this.setState({ modal: shipmentData });
+  };
+
+  closeModal = () => {
+    this.setState({ modal: false, trackingNumber: "" });
+  };
 
   handleFilter = () => {
     this.setState(
@@ -169,19 +172,23 @@ class ShipmentList extends React.Component {
   };
 
   changeCheckbox = (event, uuid) => {
-    event.stopPropagation()
-    let item = document.getElementById('tablerow-1');
-    switch(item.getAttribute('aria-checked')) {
-        case "true":
-            item.setAttribute('aria-checked', "false");
-            this.handleClick(event, uuid)
-            break;
-        case "false":
-            item.setAttribute('aria-checked', "true");
-            this.handleClick(event, uuid)
-            break;
+    event.stopPropagation();
+    let item = document.getElementById("tablerow-1");
+    switch (item.getAttribute("aria-checked")) {
+      case "true":
+        item.setAttribute("aria-checked", "false");
+        this.handleClick(event, uuid);
+        break;
+      case "false":
+        item.setAttribute("aria-checked", "true");
+        this.handleClick(event, uuid);
+        break;
     }
-  }
+  };
+
+  handleChanges = e => {
+    this.setState({ [e.target.name]: e.target.value });
+  };
 
   handleChangePage = (event, page) => {
     this.setState({ page });
@@ -200,31 +207,6 @@ class ShipmentList extends React.Component {
       rowsPerPage - Math.min(rowsPerPage, data.length - page * rowsPerPage);
     return (
       <Paper className={classes.root}>
-        {/* {this.state.filter ? (
-          <FormGroup>
-            <FormControlLabel
-              control={
-                <Switch
-                  className={classes.switch}
-                  onClick={() => this.handleFilter()}
-                />
-              }
-              label="Viewing Untracked Packages"
-            />
-          </FormGroup>
-        ) : (
-          <FormGroup>
-            <FormControlLabel
-              control={
-                <Switch
-                  className={classes.switch}
-                  onClick={() => this.handleFilter()}
-                />
-              }
-              label="Viewing Tracked Packages"
-            />
-          </FormGroup>
-        )} */}
         <EnhancedTableToolbar
           {...this.props}
           filter={this.state.filter}
@@ -245,13 +227,12 @@ class ShipmentList extends React.Component {
               onSelectAllClick={this.handleSelectAllClick}
               onRequestSort={this.handleRequestSort}
               rowCount={data.length}
-
             />
             <TableBody>
               {this.state.data &&
                 stableSort(data, getSorting(order, orderBy))
                   .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                  .map((shipment) => {
+                  .map(shipment => {
                     const isSelected = this.isSelected(shipment.uuid);
                     return (
                       <Shipment
@@ -286,12 +267,17 @@ class ShipmentList extends React.Component {
           onChangePage={this.handleChangePage}
           onChangeRowsPerPage={this.handleChangeRowsPerPage}
         />
-        {(!!this.state.modal) && (<ViewShipmentModal
-        shipment={this.state.modal}
-        openModal={this.openModal}
-        closeModal={this.closeModal}
-        modalState={!!this.state.modal}
-        />)}
+        {!!this.state.modal && (
+          <ViewShipmentModal
+            shipment={this.state.modal}
+            openModal={this.openModal}
+            closeModal={this.closeModal}
+            modalState={!!this.state.modal}
+            trackingNumber={this.state.trackingNumber}
+            handleChanges={this.handleChanges}
+            submitTracking={this.submitTracking}
+          />
+        )}
       </Paper>
     );
   }

--- a/src/containers/shipmentView/ShipmentListView.js
+++ b/src/containers/shipmentView/ShipmentListView.js
@@ -42,10 +42,8 @@ class ShipmentListView extends Component {
     this.props.getShipments();
   }
 
-  addShipment = (tracId, prodId, event) => {
-    event.stopPropagation();
-    this.props.addShipment(tracId, prodId);
-    return <Redirect to="/" />;
+  addShipment = (trackingNumber, uuid) => {
+    this.props.addShipment(trackingNumber, uuid);
   };
 
   deleteShipment = (uuid, currentPage, currentRowsPerPage, currentFilter) => {

--- a/src/store/actions/shipmentActions.js
+++ b/src/store/actions/shipmentActions.js
@@ -26,15 +26,14 @@ export const DELETE_SELECTED = 'DELETE_SELECTED';
 
 export const DELETE_ALL_SELECTED = 'DELETE_ALL_SELECTED';
 
-export const addShipment = (trackingNumber, productId) => dispatch => {
+export const addShipment = (trackingNumber, uuid) => dispatch => {
 	const trackingRequest = {
 		trackingNumber,
-		productId,
 	};
 	dispatch({ type: ADDING_SHIPMENT });
-
+    console.log("trackingnumber submitted", trackingNumber, uuid)
 	axios
-		.post('/shipments/addweb', trackingRequest)
+		.post(`/shipments/addweb/${uuid}`, trackingRequest)
 		.then(res =>
 			dispatch({ type: ADDING_SHIPMENT_SUCCESSFUL, payload: res.data }),
 		)

--- a/src/store/reducers/shipmentsReducer.js
+++ b/src/store/reducers/shipmentsReducer.js
@@ -31,7 +31,8 @@ const initialState = {
   deleting: false,
   success: false,
   failure: false,
-  error: null
+  error: null,
+  adderror: null
 };
 
 const shipmentsReducer = (state = initialState, action) => {


### PR DESCRIPTION

Using the modal that is accessed from the untracked packages portion of the shipments table, the input field can be used to add tracking numbers to track shipments. Further changes will include client-side handling of 400 errors, for example if the tracking number is not valid.